### PR TITLE
비동기 처리를 위한 Hooks 구현

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "@testing-library/user-event": "^13.5.0",
         "@types/jest": "^27.5.2",
         "@types/node": "^16.11.47",
+        "axios": "^0.27.2",
         "concurrently": "^7.3.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -4714,6 +4715,28 @@
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axobject-query": {
@@ -20255,6 +20278,27 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.4.3.tgz",
       "integrity": "sha512-32+ub6kkdhhWick/UjvEwRchgoetXqTK14INLqbGm5U2TzBkBNF3nQtLYm8ovxSkQWArjEQvftCKryjZaATu3w=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "axobject-query": {
       "version": "2.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -57,5 +57,6 @@
     "eslint-plugin-react": "^7.30.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "typescript": "^4.7.4"
-  }
+  },
+  "proxy": "http://localhost:4000"
 }

--- a/client/package.json
+++ b/client/package.json
@@ -8,6 +8,7 @@
     "@testing-library/user-event": "^13.5.0",
     "@types/jest": "^27.5.2",
     "@types/node": "^16.11.47",
+    "axios": "^0.27.2",
     "concurrently": "^7.3.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/client/src/cores/hooks/useAPI.tsx
+++ b/client/src/cores/hooks/useAPI.tsx
@@ -1,0 +1,67 @@
+import { default as axios, Method, AxiosRequestHeaders } from 'axios';
+import { useCallback, useEffect, useState } from 'react';
+import { remote } from '../libs/api';
+
+interface APIConfig<RequestData> {
+  url: string;
+  method?: Method;
+  headers?: AxiosRequestHeaders;
+  data?: RequestData;
+}
+
+interface APIError {
+  message?: string;
+  code?: number;
+}
+
+function useAPI<RequestData>(config: APIConfig<RequestData>) {
+  const [response, setResponse] = useState();
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<APIError>();
+  const [shouldRefetch, setShouldRefetch] = useState(0);
+
+  const refetch = useCallback(() => setShouldRefetch((updateCount) => updateCount + 1), []);
+
+  useEffect(() => {
+    try {
+      (async function () {
+        setIsLoading(true);
+        const result = await remote.request(config);
+        setResponse(result?.data);
+      })();
+    } catch (error) {
+      /**
+       * TODO :: 선언적 에러핸들링 설계해보기
+       *
+       * 1) 에러의 형태 구분하기 (처리가능, 처리불가능)
+       * 2) ErrorBoundary 설정
+       */
+
+      if (axios.isAxiosError(error)) {
+        /**
+         * TODO :: 에러코드 정의하기
+         *
+         * 1) 서버에서 특정 상황에 대한 에러코드와 메시지를 같이 정의해줌
+         * 2) 해당 에러코드에 따라 처리 방식 정하기
+         * 3) 그 외의 경우에는 throw하여 ErrorBoundary에게 처리를 위임
+         */
+
+        setError({
+          code: error.response?.status,
+          message: error.response?.statusText,
+        });
+
+        return;
+      }
+
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [shouldRefetch]);
+
+  return { data: response, isLoading, error, refetch };
+}
+
+export default useAPI;

--- a/client/src/cores/hooks/useAPI.tsx
+++ b/client/src/cores/hooks/useAPI.tsx
@@ -14,8 +14,8 @@ interface APIError {
   code?: number;
 }
 
-function useAPI<RequestData>(config: APIConfig<RequestData>) {
-  const [response, setResponse] = useState();
+function useAPI<ResponseData, RequestData = Record<string, never>>(config: APIConfig<RequestData>) {
+  const [response, setResponse] = useState<ResponseData>();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<APIError>();
   const [shouldRefetch, setShouldRefetch] = useState(0);

--- a/client/src/cores/libs/api.ts
+++ b/client/src/cores/libs/api.ts
@@ -1,5 +1,5 @@
 import axios from 'axios';
 
 export const remote = axios.create({
-  baseURL: process.env.NODE_ENV === 'development' ? 'http://localhost:4000/api' : '/api',
+  baseURL: '/api',
 });

--- a/client/src/cores/libs/api.ts
+++ b/client/src/cores/libs/api.ts
@@ -1,0 +1,5 @@
+import axios from 'axios';
+
+export const remote = axios.create({
+  baseURL: process.env.NODE_ENV === 'development' ? 'http://localhost:4000/api' : '/api',
+});

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -2,6 +2,8 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe } from '@nestjs/common';
 import { AppModule } from './app.module';
 
+const PORT = process.env.NODE_ENV === 'production' ? 3000 : 4000;
+
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
   app.useGlobalPipes(
@@ -12,6 +14,6 @@ async function bootstrap() {
     }),
   );
   app.setGlobalPrefix('api');
-  await app.listen(3000);
+  await app.listen(PORT);
 }
 bootstrap();


### PR DESCRIPTION
* closes #12

## 💥 PR Point

응답값과 요청 body의 타입을 제네릭으로 받도록 구현했어요.
이 커스텀훅을 사용하는 곳에서(=특정 데이터를 사용하기 위해 요청하는 곳) 타입을 정의해서 넘겨주는 것을 의도했습니다!

그 외의 사용법은 axios 인스턴스에 옵션 넘기는 방식과 동일합니다!

이번 프로젝트에서 제대로 해보고 싶은 에러 핸들링 부분을 위해 앞으로 해야할 일을 주석으로 조금 달아놓은 점 양해 바랍니다..

## 🕰 실제 소요시간

1h 10m (10m 오버)

## 😭 어려웠던 점

AxiosError github를 좀 살펴보면서 어떻게 error을 나만의 방식으로 래핑해야할지 감을 좀 잡고 있어요.
아직 정확히는 모르겠으나 곧 도전해볼 예정입니다.

곧이라 함은.. 메인페이지 마크업까지 완성해서 GET요청 연결시킨 상태를 말합니다 ㅎㅎ
