### PR TITLE
Entry(App) 컴포넌트 만들기

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,68 +1,45 @@
-import styled from 'styled-components';
-import Button from './components/common/Button';
-import mixin from './cores/styles/mixin';
-import { ReactComponent as CardIcon } from './assets/icons/payment-card.svg';
-import { ReactComponent as CashIcon } from './assets/icons/10000.svg';
+import IdleKioskScreen from './components/IdleKioskScreen';
+import KioskManager from './components/KioskManager';
+import useAPI, { BaseAPI } from './cores/hooks/useAPI';
+import useKioskStatus from './cores/hooks/useKioksStatus';
 
-function App() {
-  return (
-    <div>
-      <P>
-        Lorem ipsum dolor sit amet consectetur adipisicing elit. Sint culpa, perspiciatis cum sequi
-        quae dolores distinctio hic eius iusto commodi neque odit voluptatem. Quibusdam in, voluptas
-        aliquam adipisci incidunt quidem.
-      </P>
-      <PPAP />
-      <Button variant="contained" color="primary">
-        담기
-      </Button>
-      <Button variant="contained" color="gray02">
-        돌아가기
-      </Button>
-      <br />
-      <br />
-      <Button variant="outlined" color="primary" size="sm">
-        Grande
-      </Button>
-      <br />
-      <br />
-      <Button
-        variant="contained"
-        color="primary"
-        size="sm"
-        extraStyle={{
-          fontWeight: '100',
-        }}
-      >
-        Tall
-      </Button>
-      <br />
-      <br />
-      <Button variant="contained" color="primary" size="huge" startIcon={CardIcon}>
-        카드결제
-      </Button>
-      <br />
-      <br />
-      <Button variant="contained" color="primary" size="huge" startIcon={CashIcon}>
-        현금결제
-      </Button>
-    </div>
-  );
+interface Menu {
+  id: number;
+  name: string;
+  price: number;
+  description: string;
+  thumbnail: string;
+  specificTemperatureOnly: 'HOT' | 'ICED' | null;
 }
 
-const P = styled.p`
-  width: 200px;
-  color: ${({ theme }) => theme.colors.primary};
-  ${mixin.textEllipsis(2)}
-`;
+export interface CategorizedMenu {
+  id: number;
+  name: string;
+  items: Menu[];
+}
 
-const PPAP = styled.p`
-  width: 200px;
-  height: 300px;
-  ${mixin.backgroundImage(
-    'https://noticon-static.tammolo.com/dgggcrkxq/image/upload/v1567008394/noticon/ohybolu4ensol1gzqas1.png',
-    { contain: true, repeat: true },
-  )}
-`;
+function App() {
+  const { data, isLoading } = useAPI({
+    url: 'menu',
+    method: 'GET',
+  }) as BaseAPI<CategorizedMenu>;
+
+  const { kioskStatus } = useKioskStatus();
+
+  const screenHandler = () => {
+    switch (kioskStatus) {
+      case 'IDLE':
+        return <IdleKioskScreen isMenuReady={Boolean(!isLoading && data)} />;
+      case 'SHOPPING':
+        if (!data) throw Error('키오스크 데이터를 불러오지 못했어요.');
+        // 최상단 Error Boundary에 의해 처리되게 할 예정
+        return <KioskManager data={data} />;
+      default:
+        return <IdleKioskScreen isMenuReady={Boolean(!isLoading && data)} />;
+    }
+  };
+
+  return screenHandler();
+}
 
 export default App;

--- a/client/src/components/IdleKioskScreen/index.tsx
+++ b/client/src/components/IdleKioskScreen/index.tsx
@@ -1,0 +1,19 @@
+import { changeKioskStatus } from '../../cores/hooks/useKioksStatus';
+import Button from '../common/Button';
+
+function IdleKioskScreen({ isMenuReady }: { isMenuReady: boolean }) {
+  const moveToKioskMain = () => {
+    if (!isMenuReady) return;
+    changeKioskStatus('SHOPPING');
+  };
+
+  return (
+    <main>
+      <Button variant="contained" color="gray02" onClick={moveToKioskMain}>
+        주문하러가요.
+      </Button>
+    </main>
+  );
+}
+
+export default IdleKioskScreen;

--- a/client/src/components/KioskManager/index.tsx
+++ b/client/src/components/KioskManager/index.tsx
@@ -1,0 +1,19 @@
+import { CategorizedMenu } from '../../App';
+import { changeKioskStatus } from '../../cores/hooks/useKioksStatus';
+import Button from '../common/Button';
+
+interface KioskProps {
+  data: CategorizedMenu;
+}
+
+function KioskManager({ data }: KioskProps) {
+  return (
+    <div>
+      <Button variant="contained" color="primary" onClick={() => changeKioskStatus('IDLE')}>
+        키오스크 메인으로~
+      </Button>
+    </div>
+  );
+}
+
+export default KioskManager;

--- a/client/src/components/common/Button.tsx
+++ b/client/src/components/common/Button.tsx
@@ -60,6 +60,7 @@ function Button(props: ButtonProps) {
     startIcon: StartIcon,
     endIcon: EndIcon,
     extraStyle,
+    onClick,
   } = props;
   return (
     <StButton
@@ -68,6 +69,7 @@ function Button(props: ButtonProps) {
       color={color}
       size={size}
       isAnyIcon={!!StartIcon || !!EndIcon}
+      onClick={onClick}
     >
       {StartIcon && <StartIcon />}
       {children}

--- a/client/src/cores/hooks/useAPI.tsx
+++ b/client/src/cores/hooks/useAPI.tsx
@@ -14,21 +14,36 @@ interface APIError {
   code?: number;
 }
 
-function useAPI<ResponseData, RequestData = Record<string, never>>(config: APIConfig<RequestData>) {
-  const [response, setResponse] = useState<ResponseData>();
+export interface BaseAPI<Response> {
+  data?: Response;
+  isLoading: boolean;
+  refetch: () => void;
+  error?: APIError;
+}
+
+export type LazyAPI<Response> = [
+  () => Promise<Response | undefined>,
+  Pick<BaseAPI<Response>, 'isLoading' | 'error'>,
+];
+
+function useAPI<RequestData = Record<string, never>>(
+  config: APIConfig<RequestData>,
+  isLazy = false,
+) {
+  const [response, setResponse] = useState();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<APIError>();
   const [shouldRefetch, setShouldRefetch] = useState(0);
 
   const refetch = useCallback(() => setShouldRefetch((updateCount) => updateCount + 1), []);
 
-  useEffect(() => {
+  const fetchFn = async () => {
     try {
-      (async function () {
-        setIsLoading(true);
-        const result = await remote.request(config);
-        setResponse(result?.data);
-      })();
+      setIsLoading(true);
+      const result = await remote.request(config);
+      setResponse(result?.data);
+
+      return result?.data;
     } catch (error) {
       /**
        * TODO :: 선언적 에러핸들링 설계해보기
@@ -38,6 +53,7 @@ function useAPI<ResponseData, RequestData = Record<string, never>>(config: APICo
        */
 
       if (axios.isAxiosError(error)) {
+        console.log('isAxiosError');
         /**
          * TODO :: 에러코드 정의하기
          *
@@ -58,8 +74,15 @@ function useAPI<ResponseData, RequestData = Record<string, never>>(config: APICo
     } finally {
       setIsLoading(false);
     }
+  };
+
+  useEffect(() => {
+    if (isLazy) return;
+    fetchFn();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [shouldRefetch]);
+
+  if (isLazy) return [fetchFn, { isLoading, error }];
 
   return { data: response, isLoading, error, refetch };
 }

--- a/client/src/cores/hooks/useAPI.tsx
+++ b/client/src/cores/hooks/useAPI.tsx
@@ -53,7 +53,6 @@ function useAPI<RequestData = Record<string, never>>(
        */
 
       if (axios.isAxiosError(error)) {
-        console.log('isAxiosError');
         /**
          * TODO :: 에러코드 정의하기
          *

--- a/client/src/cores/hooks/useKioksStatus.tsx
+++ b/client/src/cores/hooks/useKioksStatus.tsx
@@ -16,14 +16,15 @@ function useKioskStatus() {
   const [kioskStatus, setKioskStatus] = useState<KioskStatus>('IDLE');
 
   useEffect(() => {
-    function handleKioskChange({ detail }: CustomEvent) {
-      const { nextKioskStatus } = detail;
+    function handleKioskChange(e: Event) {
+      if (!(e instanceof CustomEvent)) return;
+      const { nextKioskStatus } = e.detail;
       setKioskStatus(nextKioskStatus);
     }
-    window.addEventListener('kioskstatuschange', handleKioskChange as EventListener);
+    window.addEventListener('kioskstatuschange', handleKioskChange);
 
     return () => {
-      window.removeEventListener('kioskstatuschange', handleKioskChange as EventListener);
+      window.removeEventListener('kioskstatuschange', handleKioskChange);
     };
   }, []);
 

--- a/client/src/cores/hooks/useKioksStatus.tsx
+++ b/client/src/cores/hooks/useKioksStatus.tsx
@@ -19,8 +19,6 @@ function useKioskStatus() {
     function handleKioskChange({ detail }: CustomEvent) {
       const { nextKioskStatus } = detail;
       setKioskStatus(nextKioskStatus);
-
-      console.log('키오스크체인지?');
     }
     window.addEventListener('kioskstatuschange', handleKioskChange as EventListener);
 

--- a/client/src/cores/hooks/useKioksStatus.tsx
+++ b/client/src/cores/hooks/useKioksStatus.tsx
@@ -1,0 +1,37 @@
+import { useEffect, useState } from 'react';
+
+type KioskStatus = 'IDLE' | 'SHOPPING';
+
+export const changeKioskStatus = (nextKioskStatus: KioskStatus) => {
+  const kioskStatusChangeEvent = new CustomEvent('kioskstatuschange', {
+    detail: {
+      nextKioskStatus,
+    },
+  });
+
+  dispatchEvent(kioskStatusChangeEvent);
+};
+
+function useKioskStatus() {
+  const [kioskStatus, setKioskStatus] = useState<KioskStatus>('IDLE');
+
+  useEffect(() => {
+    function handleKioskChange({ detail }: CustomEvent) {
+      const { nextKioskStatus } = detail;
+      setKioskStatus(nextKioskStatus);
+
+      console.log('키오스크체인지?');
+    }
+    window.addEventListener('kioskstatuschange', handleKioskChange as EventListener);
+
+    return () => {
+      window.removeEventListener('kioskstatuschange', handleKioskChange as EventListener);
+    };
+  }, []);
+
+  return {
+    kioskStatus,
+  };
+}
+
+export default useKioskStatus;


### PR DESCRIPTION
* closes #14

## 💥 PR Point

제 설계에 따르면 키오스크 진입화면(A)과 메뉴가 나타나는 화면(B) 두개의 페이지로 구성이 됩니다.

하지만 라우터를 사용하지 않기 때문에 최상단에서 키오스크의 상태에 따라 A 혹은 B를 보여주어야하는 요구사항이 있었어요.
이걸 어떻게 해결할까? 설계 단에서 크게 3가지 방법을 고민해봤어요.

최상단에서 상태를 정의하는 것은 고정이구요.

1. 상태를 필요한 컴포넌트까지 props로 전달한다.
2. Context API 를 활용해 Provider로 전역 제공한다.
3. Custom Event를 활용해 어디서든 event를 발생시키기만 하면 상태를 변경할 수 있도록 한다.

1번의 경우 전달되는 depth가 깊어질 것 같아 제외했습니다.
> App->KioskManager->ShoppingCart->Modal->X버튼
최소 3~4번은 내려줘야할 것 같다고 판단했음

그래서 2번과 3번을 고민했는데 

하위의 컴포넌트에게 현재 키오스크의 상태가 무엇인가?는 중요하지 않았어요.
그저 `키오스크의 상태를 IDLE 혹은 SHOPPING 상태로 변경시켜주는 함수`가 필요했습니다.
이러한 이유로 결국 3번을 선택해서 구현했어요.

뭐.. 사실 라우터를 사용하면 쉽게 해결될 문제였긴합니다만 라우터를 사용하지 않는다라는 제약 속에서 한 페이지 자체를  조금 더 깔끔하게 교체하기 위한 로직을 고민해본 것 같습니다.

## 🕰 실제 소요시간

1h 15m

## 😭 어려웠던 점

공용버튼 컴포넌트에 onclick props 등록안해놓고 custom 이벤트가 동작안하니까 
내 로직에 문제가 있는 줄 알고 우울할뻔 했지만 금방 해결했슴다 ㅎ_ㅎ