### PR TITLE
사용자가 Idle 상태인지 판단하여 타이머 동작시키기

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,7 +1,7 @@
 import IdleKioskScreen from './components/IdleKioskScreen';
 import KioskManager from './components/KioskManager';
 import useAPI, { BaseAPI } from './cores/hooks/useAPI';
-import useKioskStatus from './cores/hooks/useKioksStatus';
+import useKioskStatus, { KioskStatus } from './cores/hooks/useKioksStatus';
 
 export interface MenuType {
   id: number;
@@ -29,9 +29,9 @@ function App() {
 
   const screenHandler = () => {
     switch (kioskStatus) {
-      case 'IDLE':
+      case KioskStatus.IDLE:
         return <IdleKioskScreen isMenuReady={Boolean(!isLoading && data)} />;
-      case 'SHOPPING':
+      case KioskStatus.SHOPPING:
         if (!data) throw Error('키오스크 데이터를 불러오지 못했어요.');
         // 최상단 Error Boundary에 의해 처리되게 할 예정
         return <KioskManager data={data} />;

--- a/client/src/components/IdleKioskScreen/index.tsx
+++ b/client/src/components/IdleKioskScreen/index.tsx
@@ -1,10 +1,10 @@
-import { changeKioskStatus } from '../../cores/hooks/useKioksStatus';
+import { changeKioskStatus, KioskStatus } from '../../cores/hooks/useKioksStatus';
 import Button from '../common/Button';
 
 function IdleKioskScreen({ isMenuReady }: { isMenuReady: boolean }) {
   const moveToKioskMain = () => {
     if (!isMenuReady) return;
-    changeKioskStatus('SHOPPING');
+    changeKioskStatus(KioskStatus.SHOPPING);
   };
 
   return (

--- a/client/src/components/KioskManager/KioskCart/ShoppingCart.tsx
+++ b/client/src/components/KioskManager/KioskCart/ShoppingCart.tsx
@@ -1,10 +1,12 @@
-import styled from 'styled-components';
+import styled, { css } from 'styled-components';
 import mixin from '../../../cores/styles/mixin';
 import Button from '../../common/Button';
+import { ColumnWrapper } from '../../common/Wrapper';
 import { CartInfoType } from '../index';
 import CartElement from './CartElement';
 
 interface ShoppingCartProps {
+  resetTimeout: number;
   cartInfoList: CartInfoType[];
   removeFromCartInfoList: (cartElementId: number) => void;
   clearCartInfoList: () => void;
@@ -12,7 +14,13 @@ interface ShoppingCartProps {
 }
 
 function ShoppingCart(props: ShoppingCartProps) {
-  const { cartInfoList, removeFromCartInfoList, clearCartInfoList, openPaymentModal } = props;
+  const {
+    resetTimeout,
+    cartInfoList,
+    removeFromCartInfoList,
+    clearCartInfoList,
+    openPaymentModal,
+  } = props;
 
   const isCartEmpty = cartInfoList.length === 0;
 
@@ -42,7 +50,14 @@ function ShoppingCart(props: ShoppingCartProps) {
 
       <CartButtonWrapper>
         <Button onClick={clearCartInfoList} variant="contained" size="md" color="gray02">
-          전체 취소
+          <ColumnWrapper>
+            {!isCartEmpty && (
+              <TimerWarnText shouldBlink={resetTimeout % 2 === 1}>
+                {resetTimeout}초 남음
+              </TimerWarnText>
+            )}
+            <span>전체 취소</span>
+          </ColumnWrapper>
         </Button>
         <Button onClick={handlePayment} variant="contained" size="md" color="primary">
           <PaymentButtonInnerText>
@@ -94,6 +109,34 @@ const PaymentButtonInnerText = styled.div`
     font-size: 20px;
     font-weight: 600;
     ${mixin.concatWonUnit}
+  }
+`;
+
+const TimerWarnText = styled.p<{ shouldBlink: boolean }>`
+  ${({ theme, shouldBlink }) =>
+    shouldBlink
+      ? css`
+          color: ${theme.colors.yellow};
+          font-size: 0.8em;
+          animation: shakeHard ease infinite 0.5s;
+        `
+      : css`
+          font-size: 0.8em;
+          color: inherit;
+        `};
+
+  @keyframes shakeHard {
+    0% {
+      transform: rotate(-5deg);
+    }
+
+    50% {
+      transform: translateY(-10px) rotate(0deg);
+    }
+
+    100% {
+      transform: rotate(5deg);
+    }
   }
 `;
 

--- a/client/src/components/KioskManager/index.tsx
+++ b/client/src/components/KioskManager/index.tsx
@@ -164,12 +164,12 @@ function KioskManager({ data }: KioskProps) {
         <section>
           <MenuGrid>{showMenuItemIntoGrid()}</MenuGrid>
           <ShoppingCart
+            resetTimeout={remainTime}
             openPaymentModal={openPaymentModal}
             cartInfoList={cartInfoList}
             clearCartInfoList={clearCartInfoList}
             removeFromCartInfoList={removeFromCartInfoList}
           />
-          <h3>{remainTime}초 남음!</h3>
         </section>
       </KioskContent>
       <Modal isOpen={isShoppingModalOpen}>

--- a/client/src/cores/hooks/useKioksStatus.tsx
+++ b/client/src/cores/hooks/useKioksStatus.tsx
@@ -1,8 +1,13 @@
 import { useEffect, useState } from 'react';
 
-type KioskStatus = 'IDLE' | 'SHOPPING';
+export const KioskStatus = {
+  IDLE: 'IDLE',
+  SHOPPING: 'SHOPPING',
+} as const;
 
-export const changeKioskStatus = (nextKioskStatus: KioskStatus) => {
+type KioskStatusType = keyof typeof KioskStatus;
+
+export const changeKioskStatus = (nextKioskStatus: KioskStatusType) => {
   const kioskStatusChangeEvent = new CustomEvent('kioskstatuschange', {
     detail: {
       nextKioskStatus,
@@ -13,7 +18,7 @@ export const changeKioskStatus = (nextKioskStatus: KioskStatus) => {
 };
 
 function useKioskStatus() {
-  const [kioskStatus, setKioskStatus] = useState<KioskStatus>('IDLE');
+  const [kioskStatus, setKioskStatus] = useState<KioskStatusType>(KioskStatus.IDLE);
 
   useEffect(() => {
     function handleKioskChange(e: Event) {

--- a/client/src/cores/hooks/useTimer.tsx
+++ b/client/src/cores/hooks/useTimer.tsx
@@ -1,0 +1,47 @@
+import { useEffect, useRef, useState } from 'react';
+
+function useTimer(initialTimeout: number) {
+  const [remainTime, setRemainTime] = useState(initialTimeout);
+  const remainTimeRef = useRef<number>(initialTimeout);
+  const intervalRef = useRef<NodeJS.Timer | null>(null);
+
+  useEffect(() => {
+    remainTimeRef.current = remainTime;
+  }, [remainTime]);
+
+  const _setInterval = (timeout: number, cb: () => unknown) => {
+    setRemainTime(timeout);
+    intervalRef.current = setInterval(() => {
+      setRemainTime((prevRemainTime) => prevRemainTime - 1);
+
+      if (remainTimeRef.current - 1 === 0) {
+        _clearInterval();
+        cb();
+      }
+    }, 1000);
+  };
+
+  const _clearInterval = () => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    intervalRef.current = null;
+  };
+
+  const invoke = (cb: () => unknown) => {
+    if (intervalRef.current) return;
+
+    _setInterval(remainTime, cb);
+  };
+
+  const pause = () => {
+    _clearInterval();
+  };
+
+  const clear = () => {
+    _clearInterval();
+    setRemainTime(initialTimeout);
+  };
+
+  return { remainTime, invoke, clear, pause };
+}
+
+export default useTimer;

--- a/client/src/cores/hooks/useTimer.tsx
+++ b/client/src/cores/hooks/useTimer.tsx
@@ -15,7 +15,7 @@ function useTimer(initialTimeout: number) {
       setRemainTime((prevRemainTime) => prevRemainTime - 1);
 
       if (remainTimeRef.current - 1 === 0) {
-        _clearInterval();
+        clear();
         cb();
       }
     }, 1000);

--- a/client/src/cores/styles/theme.ts
+++ b/client/src/cores/styles/theme.ts
@@ -7,6 +7,7 @@ const colors = {
   gray03: '#f4f4f4',
   background: '#ededed',
   background02: '#f8f8f8',
+  yellow: '#fff61f',
 } as const;
 
 export type ColorType = typeof colors;


### PR DESCRIPTION
* closes #28 

## 💥 PR Point

이전 task에서 작성했던 영수증 자동 닫기 코드에서 영감을 받아서 
타이머 로직을 useTimer 커스텀 훅으로 분리했어요.

확실히 커스텀 훅으로 분리해서 필요한 함수만 가져와서 사용하니까 사용하는 입장에선 굉장히 편리하더군요

커스텀 훅의 기능은 다음과 같아요.
1. invoke(cb): 훅 내부의 타임아웃 상태값만큼의 타이머를 실행하고, 만료 시 cb를 호출해요.
2. pause(): 현재 진행 중인 타이머가 있다면 중지해요. 이 때 타임아웃 값은 유지됩니다.
3. clear(): 현재 진행 중인 타이머를 중지하고 타임아웃 값도 초기화합니다.

이런 식으로 필요한 함수를 미리 정의하고 로직을 작성하니 좀 수월했던 것 같아요!

## 🕰 실제 소요시간

2h 정도 걸렸네요!

## 😭 어려웠던 점

생각보다 로직을 분리하는게 어렵지 않았어요. 
예상 시간보다 훨씬 적게걸려서 기분이 좋네요 
