### PR TITLE
간단한 애니메이션 추가하기

### DIFF
--- a/client/src/components/KioskManager/KioskMenu/MenuGrid.tsx
+++ b/client/src/components/KioskManager/KioskMenu/MenuGrid.tsx
@@ -2,26 +2,40 @@ import styled from 'styled-components';
 
 interface MenuGridProps {
   children: JSX.Element[];
+  selectedCategoryIdx: number;
 }
 
 function MenuGrid(props: MenuGridProps) {
-  const { children } = props;
-  return <SectionContainer>{children}</SectionContainer>;
+  const { children, selectedCategoryIdx } = props;
+
+  const currentTranslateX = `translateX(${-100 * selectedCategoryIdx}%)`;
+
+  return <GridSection currentTranslateX={currentTranslateX}>{children}</GridSection>;
 }
 
-const SectionContainer = styled.section`
+const GridSection = styled.section<{ currentTranslateX: string }>`
   flex: 2;
 
   height: 600px;
-  overflow-y: auto;
-  padding: 5px;
 
-  display: grid;
-  grid-template-columns: repeat(3, 198px);
-  justify-content: flex-start;
-  gap: 24px;
+  display: flex;
+  overflow-x: hidden;
 
-  user-select: none;
+  & > div.translated-box {
+    transform: ${({ currentTranslateX }) => currentTranslateX};
+    transition: transform ease 0.3s;
+    flex: 0 0 auto;
+    width: 100%;
+    overflow-y: auto;
+    padding: 5px;
+
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    justify-content: flex-start;
+    gap: 24px;
+
+    user-select: none;
+  }
 `;
 
 export default MenuGrid;

--- a/client/src/components/KioskManager/index.tsx
+++ b/client/src/components/KioskManager/index.tsx
@@ -50,9 +50,12 @@ function KioskManager({ data }: KioskProps) {
     }));
 
   const showMenuItemIntoGrid = () => {
-    if (!data[selectedCategoryIdx]?.items) return [];
-    return data[selectedCategoryIdx].items.map((menu) => (
-      <MenuItem key={menu.id} menuInfo={menu} onClickMenu={openModalWithSelectedMenu} />
+    return data.map((menuData) => (
+      <div key={menuData.id} className="translated-box">
+        {menuData.items.map((menu) => (
+          <MenuItem key={menu.id} menuInfo={menu} onClickMenu={openModalWithSelectedMenu} />
+        ))}
+      </div>
     ));
   };
 
@@ -162,7 +165,7 @@ function KioskManager({ data }: KioskProps) {
           changeCategoryIdx={changeCategoryIdx}
         />
         <section>
-          <MenuGrid>{showMenuItemIntoGrid()}</MenuGrid>
+          <MenuGrid selectedCategoryIdx={selectedCategoryIdx}>{showMenuItemIntoGrid()}</MenuGrid>
           <ShoppingCart
             resetTimeout={remainTime}
             openPaymentModal={openPaymentModal}


### PR DESCRIPTION
* closes #37 

## 💥 PR Point

애니메이션은 포기해야하나 싶었는데 갑자기 의욕이 솓구쳐서 우당탕탕 만들어봤습니다.
메뉴목록 슬라이드를 하기위해 전체데이터를 불러오고 overflow-x:hidden 처리해주었어요.

그리고 현재 선택된 카테고리의 index에 의해 동적으로 translateX 하게 구현했습니다

## 🕰 실제 소요시간

1h30m

## 😭 어려웠던 점

아까 루터에서 급하게 할 때는 안되던게 집에와서 차근차근 생각해보고 하니까 금방 됐어요 ㅎㅎ

## 📹 데모

![애니메이션움짤](https://user-images.githubusercontent.com/22493971/184152629-85dc010d-d8fc-4b4d-a2a6-ee8c67b573a2.gif)
